### PR TITLE
Add dark theme persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Dark Mode
+
+This app supports system-aware dark mode. By default it follows your device's
+theme setting. You can toggle between light and dark themes from the home
+screen using the theme icon in the top-right corner. Your choice is saved
+locally so the app remembers it on the next launch.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Dark Mode
+
+This app supports system-aware dark mode. By default it follows your device's
+theme setting. You can toggle between light and dark themes from the home
+screen using the theme icon in the top-right corner.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,20 +15,54 @@ void main() async {
 
   // Abre a box principal onde as listas serão armazenadas
   await Hive.openBox<Checklist>('checklists');
+  // Abre a box de configurações para armazenar preferências do usuário
+  await Hive.openBox('settings');
 
   runApp(MyEasyListApp());
 }
 
-class MyEasyListApp extends StatelessWidget {
+class MyEasyListApp extends StatefulWidget {
+  @override
+  State<MyEasyListApp> createState() => _MyEasyListAppState();
+}
+
+class _MyEasyListAppState extends State<MyEasyListApp> {
+  late Box settingsBox;
+  ThemeMode _themeMode = ThemeMode.system;
+
+  @override
+  void initState() {
+    super.initState();
+    settingsBox = Hive.box('settings');
+    final savedModeIndex = settingsBox.get('themeMode', defaultValue: ThemeMode.system.index) as int;
+    _themeMode = ThemeMode.values[savedModeIndex];
+  }
+
+  void _toggleTheme() {
+    setState(() {
+      _themeMode = _themeMode == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
+      settingsBox.put('themeMode', _themeMode.index);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'MyEasyList',
+      themeMode: _themeMode,
       theme: ThemeData(
         primarySwatch: Colors.teal,
         useMaterial3: true,
       ),
-      home: HomeScreen(),
+      darkTheme: ThemeData(
+        brightness: Brightness.dark,
+        primarySwatch: Colors.teal,
+        useMaterial3: true,
+      ),
+      home: HomeScreen(
+        onToggleTheme: _toggleTheme,
+        themeMode: _themeMode,
+      ),
       debugShowCheckedModeBanner: false,
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,16 +19,39 @@ void main() async {
   runApp(MyEasyListApp());
 }
 
-class MyEasyListApp extends StatelessWidget {
+class MyEasyListApp extends StatefulWidget {
+  @override
+  State<MyEasyListApp> createState() => _MyEasyListAppState();
+}
+
+class _MyEasyListAppState extends State<MyEasyListApp> {
+  ThemeMode _themeMode = ThemeMode.system;
+
+  void _toggleTheme() {
+    setState(() {
+      _themeMode =
+          _themeMode == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'MyEasyList',
+      themeMode: _themeMode,
       theme: ThemeData(
         primarySwatch: Colors.teal,
         useMaterial3: true,
       ),
-      home: HomeScreen(),
+      darkTheme: ThemeData(
+        brightness: Brightness.dark,
+        primarySwatch: Colors.teal,
+        useMaterial3: true,
+      ),
+      home: HomeScreen(
+        onToggleTheme: _toggleTheme,
+        themeMode: _themeMode,
+      ),
       debugShowCheckedModeBanner: false,
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,7 +5,14 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
+  final VoidCallback onToggleTheme;
+  final ThemeMode themeMode;
+
+  const HomeScreen({
+    super.key,
+    required this.onToggleTheme,
+    required this.themeMode,
+  });
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -34,7 +41,18 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Minhas Listas'), centerTitle: true),
+      appBar: AppBar(
+        title: Text('Minhas Listas'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: Icon(widget.themeMode == ThemeMode.dark
+                ? Icons.dark_mode
+                : Icons.light_mode),
+            onPressed: widget.onToggleTheme,
+          ),
+        ],
+      ),
       body: ValueListenableBuilder(
         valueListenable: checklistBox.listenable(),
         builder: (context, Box<Checklist> box, _) {


### PR DESCRIPTION
## Summary
- open a Hive box for app settings and store themeMode
- restore themeMode from Hive when the app starts
- update README with persistence note

## Testing
- `dart format lib/main.dart lib/screens/home_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865dd0b54ac8321a8397b30734bbe0d